### PR TITLE
feat: Implement full load mode functionality

### DIFF
--- a/src/py_load_eudravigilance/cli.py
+++ b/src/py_load_eudravigilance/cli.py
@@ -74,13 +74,6 @@ def run(
     if source_uri:
         settings.source_uri = source_uri
 
-    # The 'mode' is not yet used by the new run module, but could be in the future.
-    # For now, the run module implicitly handles 'delta' logic.
-    # A full implementation would pass this 'mode' to the run_etl function.
-    if mode == 'full':
-        typer.secho("Warning: 'full' mode is not fully implemented in the new run module yet. Running as 'delta'.", fg=typer.colors.YELLOW)
-
-
     if not settings.source_uri:
         typer.secho("Error: A source URI must be provided via argument or in the config file.", fg=typer.colors.RED)
         raise typer.Exit(code=1)
@@ -89,7 +82,7 @@ def run(
 
     # 2. Call the main ETL orchestration function
     try:
-        etl_run.run_etl(settings, max_workers=workers)
+        etl_run.run_etl(settings, mode=mode, max_workers=workers)
         typer.secho("\nETL process completed successfully.", fg=typer.colors.GREEN)
     except Exception as e:
         typer.secho(f"\nAn error occurred during the ETL process: {e}", fg=typer.colors.RED)


### PR DESCRIPTION
This commit introduces the full functionality for the `--mode full` option in the ETL process, addressing a key requirement from the FRD.

The orchestration logic in `run.py` has been updated to distinguish between `delta` and `full` modes. When running in `full` mode, the application now processes all discovered source files, bypassing the check for already completed files.

The `mode` parameter is now passed from the CLI through the parallel processing layer down to the database loader. This ensures that the loader executes the correct behavior, specifically truncating tables before loading data when in `full` mode.

To support this change, existing unit tests in `test_run.py` were updated to reflect the new function signatures. A new integration test, `test_full_load_truncates_data`, has been added to `test_loader_integration.py` to explicitly verify that the truncate-and-load mechanism works as expected.