### PR TITLE
Fixes a bug in the `handle_upsert` method in `PostgresLoader` where t…

### DIFF
--- a/src/py_load_eudravigilance/loader.py
+++ b/src/py_load_eudravigilance/loader.py
@@ -287,6 +287,9 @@ class PostgresLoader(LoaderInterface):
                 if col.name == "is_nullified":
                     # The nullification flag should always be updated from the source.
                     update_dict[col.name] = excluded[col.name]
+                elif col.name == version_key:
+                    # The version key should always be updated from the incoming record
+                    update_dict[col.name] = excluded[col.name]
                 elif has_nullified_col:
                     # For all other columns, keep the existing value if the new
                     # record is a nullification; otherwise, take the new value.


### PR DESCRIPTION
…he version key was not being updated during a nullification operation.

This change ensures the version key is always updated from the incoming record, allowing subsequent amendments to be processed correctly.

Additionally, this change enhances the integration test suite:
- Adds `test_icsr_nullification` to validate the correct handling of ICSR nullifications.
- Adds `test_drugs_table_loading` to explicitly verify data loading into the `drugs` table.