### PR TITLE
feat(tests): Add integration tests for loader scenarios

### DIFF
--- a/tests/data/test_amendment.xml
+++ b/tests/data/test_amendment.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ichicsr xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:hl7-org:v3 ICH-ICSR.xsd">
+  <ichicsrMessage>
+    <messageheader>
+      <messagetype>ichicsr</messagetype>
+      <messageformatversion>2.1</messageformatversion>
+      <messagesenderidentifier>SENDER-ID-UPDATED</messagesenderidentifier>
+      <messagereceiveridentifier>RECEIVER-ID</messagereceiveridentifier>
+      <messagedate>20250102120000</messagedate>
+    </messageheader>
+    <safetyreport>
+      <safetyreportversion>2</safetyreportversion>
+      <safetyreportid>TEST-SCENARIO-01</safetyreportid>
+      <primarysourcecountry>US</primarysourcecountry>
+      <occurcountry>US</occurcountry>
+      <transmissiondateformat>204</transmissiondateformat>
+      <transmissiondate>20250102</transmissiondate>
+      <reporttype>1</reporttype>
+      <serious>1</serious>
+      <receivedateformat>102</receivedateformat>
+      <receivedate>20250101</receivedate>
+      <receiptdateformat>102</receiptdateformat>
+      <receiptdate>20250101</receiptdate>
+      <dateofmostrecentinformationformat>102</dateofmostrecentinformationformat>
+      <dateofmostrecentinformation>20250102</dateofmostrecentinformation>
+      <patient>
+        <patientinitials>JDS</patientinitials>
+        <patientonsetage>56</patientonsetage>
+        <patientsex>1</patientsex>
+      </patient>
+    </safetyreport>
+  </ichicsrMessage>
+</ichicsr>

--- a/tests/data/test_insert.xml
+++ b/tests/data/test_insert.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ichicsr xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:hl7-org:v3 ICH-ICSR.xsd">
+  <ichicsrMessage>
+    <messageheader>
+      <messagetype>ichicsr</messagetype>
+      <messageformatversion>2.1</messageformatversion>
+      <messagesenderidentifier>SENDER-ID</messagesenderidentifier>
+      <messagereceiveridentifier>RECEIVER-ID</messagereceiveridentifier>
+      <messagedate>20250101120000</messagedate>
+    </messageheader>
+    <safetyreport>
+      <safetyreportversion>1</safetyreportversion>
+      <safetyreportid>TEST-SCENARIO-01</safetyreportid>
+      <primarysourcecountry>US</primarysourcecountry>
+      <occurcountry>US</occurcountry>
+      <transmissiondateformat>204</transmissiondateformat>
+      <transmissiondate>20250101</transmissiondate>
+      <reporttype>1</reporttype>
+      <serious>1</serious>
+      <receivedateformat>102</receivedateformat>
+      <receivedate>20250101</receivedate>
+      <receiptdateformat>102</receiptdateformat>
+      <receiptdate>20250101</receiptdate>
+      <dateofmostrecentinformationformat>102</dateofmostrecentinformationformat>
+      <dateofmostrecentinformation>20250101</dateofmostrecentinformation>
+      <patient>
+        <patientinitials>JD</patientinitials>
+        <patientonsetage>55</patientonsetage>
+        <patientsex>1</patientsex>
+      </patient>
+    </safetyreport>
+  </ichicsrMessage>
+</ichicsr>

--- a/tests/data/test_nullification.xml
+++ b/tests/data/test_nullification.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ichicsr xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:hl7-org:v3 ICH-ICSR.xsd">
+  <ichicsrMessage>
+    <messageheader>
+      <messagetype>ichicsr</messagetype>
+      <messageformatversion>2.1</messageformatversion>
+      <messagesenderidentifier>SENDER-ID-NULL</messagesenderidentifier>
+      <messagereceiveridentifier>RECEIVER-ID</messagereceiveridentifier>
+      <messagedate>20250103120000</messagedate>
+    </messageheader>
+    <safetyreport>
+      <safetyreportversion>3</safetyreportversion>
+      <safetyreportid>TEST-SCENARIO-01</safetyreportid>
+      <primarysourcecountry>US</primarysourcecountry>
+      <occurcountry>US</occurcountry>
+      <transmissiondateformat>204</transmissiondateformat>
+      <transmissiondate>20250103</transmissiondate>
+      <reporttype>4</reporttype> <!-- Nullification Report Type -->
+      <serious>1</serious>
+      <receivedateformat>102</receivedateformat>
+      <receivedate>20250101</receivedate>
+      <receiptdateformat>102</receiptdateformat>
+      <receiptdate>20250101</receiptdate>
+      <dateofmostrecentinformationformat>102</dateofmostrecentinformationformat>
+      <dateofmostrecentinformation>20250103</dateofmostrecentinformation> <!-- Newer date -->
+      <reportnullification>true</reportnullification>
+      <!-- Sparse record, no patient data -->
+    </safetyreport>
+  </ichicsrMessage>
+</ichicsr>

--- a/tests/data/test_reinsert.xml
+++ b/tests/data/test_reinsert.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ichicsr xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:hl7-org:v3 ICH-ICSR.xsd">
+  <ichicsrMessage>
+    <messageheader>
+      <messagetype>ichicsr</messagetype>
+      <messageformatversion>2.1</messageformatversion>
+      <messagesenderidentifier>SENDER-ID</messagesenderidentifier>
+      <messagereceiveridentifier>RECEIVER-ID</messagereceiveridentifier>
+      <messagedate>20250101120000</messagedate>
+    </messageheader>
+    <safetyreport>
+      <safetyreportversion>1</safetyreportversion>
+      <safetyreportid>TEST-SCENARIO-01</safetyreportid>
+      <primarysourcecountry>US</primarysourcecountry>
+      <occurcountry>US</occurcountry>
+      <transmissiondateformat>204</transmissiondateformat>
+      <transmissiondate>20250101</transmissiondate>
+      <reporttype>1</reporttype>
+      <serious>1</serious>
+      <receivedateformat>102</receivedateformat>
+      <receivedate>20250101</receivedate>
+      <receiptdateformat>102</receiptdateformat>
+      <receiptdate>20250101</receiptdate>
+      <dateofmostrecentinformationformat>102</dateofmostrecentinformationformat>
+      <dateofmostrecentinformation>20250101</dateofmostrecentinformation>
+      <patient>
+        <patientinitials>JD</patientinitials>
+        <patientonsetage>55</patientonsetage>
+        <patientsex>1</patientsex>
+      </patient>
+    </safetyreport>
+  </ichicsrMessage>
+</ichicsr>

--- a/tests/data/test_stale_amendment.xml
+++ b/tests/data/test_stale_amendment.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ichicsr xmlns="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:hl7-org:v3 ICH-ICSR.xsd">
+  <ichicsrMessage>
+    <messageheader>
+      <messagetype>ichicsr</messagetype>
+      <messageformatversion>2.1</messageformatversion>
+      <messagesenderidentifier>SENDER-ID-STALE</messagesenderidentifier>
+      <messagereceiveridentifier>RECEIVER-ID</messagereceiveridentifier>
+      <messagedate>20250101120000</messagedate>
+    </messageheader>
+    <safetyreport>
+      <safetyreportversion>1</safetyreportversion>
+      <safetyreportid>TEST-SCENARIO-01</safetyreportid>
+      <primarysourcecountry>US</primarysourcecountry>
+      <occurcountry>US</occurcountry>
+      <transmissiondateformat>204</transmissiondateformat>
+      <transmissiondate>20250101</transmissiondate>
+      <reporttype>1</reporttype>
+      <serious>1</serious>
+      <receivedateformat>102</receivedateformat>
+      <receivedate>20250101</receivedate>
+      <receiptdateformat>102</receiptdateformat>
+      <receiptdate>20250101</receiptdate>
+      <dateofmostrecentinformationformat>102</dateofmostrecentinformationformat>
+      <dateofmostrecentinformation>20250101</dateofmostrecentinformation> <!-- Stale date -->
+      <patient>
+        <patientinitials>STALE</patientinitials>
+        <patientonsetage>99</patientonsetage>
+        <patientsex>2</patientsex>
+      </patient>
+    </safetyreport>
+  </ichicsrMessage>
+</ichicsr>

--- a/tests/test_loader_scenarios.py
+++ b/tests/test_loader_scenarios.py
@@ -1,0 +1,172 @@
+import pytest
+import sqlalchemy
+from testcontainers.postgres import PostgresContainer
+from pathlib import Path
+from py_load_eudravigilance.config import Settings, DatabaseConfig
+from py_load_eudravigilance.run import run_etl
+
+# Define the path to the test data directory
+TEST_DATA_DIR = Path(__file__).parent / "data"
+
+@pytest.fixture(scope="function")
+def db_container():
+    """A fixture to provide a fresh, ephemeral PostgreSQL database for each test function."""
+    with PostgresContainer("postgres:14") as container:
+        # The container is started when entering the 'with' block
+        # and automatically stopped/cleaned up on exit.
+        yield container
+
+@pytest.fixture(scope="function")
+def test_settings(db_container: PostgresContainer) -> Settings:
+    """A fixture to create a Settings object configured to use the test database."""
+    dsn = db_container.get_connection_url()
+    return Settings(
+        source_uri="", # Will be set by each test
+        schema_type="normalized",
+        database=DatabaseConfig(dsn=dsn),
+        quarantine_uri=None, # Not testing quarantine in this suite
+    )
+
+def run_single_file_etl(settings: Settings, xml_filename: str):
+    """Helper function to run the main ETL process on a single test file."""
+    file_path = TEST_DATA_DIR / xml_filename
+    settings.source_uri = str(file_path)
+
+    # Initialize the database schema for the test
+    from py_load_eudravigilance.loader import get_loader
+    loader = get_loader(settings.database.dsn)
+    loader.create_all_tables()
+
+    # Run the ETL in delta mode
+    run_etl(settings=settings, mode="delta", max_workers=1)
+
+def get_icsr_master_row(engine: sqlalchemy.engine.Engine, report_id: str) -> dict | None:
+    """Helper function to fetch a specific row from the icsr_master table."""
+    with engine.connect() as conn:
+        result = conn.execute(
+            sqlalchemy.text(f"SELECT * FROM icsr_master WHERE safetyreportid = '{report_id}'")
+        ).first()
+        return result._asdict() if result else None
+
+def test_initial_insert(db_container: PostgresContainer, test_settings: Settings):
+    """
+    Tests that processing a new XML file correctly inserts a new record
+    into the database.
+    """
+    # Arrange
+    dsn = db_container.get_connection_url()
+    engine = sqlalchemy.create_engine(dsn)
+    report_id = "TEST-SCENARIO-01"
+
+    # Act
+    run_single_file_etl(test_settings, "test_insert.xml")
+
+    # Assert
+    row = get_icsr_master_row(engine, report_id)
+    assert row is not None
+    assert row["safetyreportid"] == report_id
+    assert row["date_of_most_recent_info"] == "20250101"
+    assert row["senderidentifier"] == "SENDER-ID"
+    assert row["is_nullified"] is False
+
+
+def test_successful_amendment(db_container: PostgresContainer, test_settings: Settings):
+    """
+    Tests that processing an amendment with a newer version date correctly
+    updates the existing record.
+    """
+    # Arrange: Load the initial record first
+    dsn = db_container.get_connection_url()
+    engine = sqlalchemy.create_engine(dsn)
+    report_id = "TEST-SCENARIO-01"
+    run_single_file_etl(test_settings, "test_insert.xml")
+
+    # Act: Process the amendment file
+    run_single_file_etl(test_settings, "test_amendment.xml")
+
+    # Assert: The record should be updated
+    row = get_icsr_master_row(engine, report_id)
+    assert row is not None
+    assert row["date_of_most_recent_info"] == "20250102"
+    assert row["senderidentifier"] == "SENDER-ID-UPDATED"
+
+
+def test_nullification(db_container: PostgresContainer, test_settings: Settings):
+    """
+    Tests that a nullification record correctly updates the 'is_nullified'
+    flag and preserves existing data from the previous version.
+    """
+    # Arrange: Load an up-to-date, non-nullified record first.
+    dsn = db_container.get_connection_url()
+    engine = sqlalchemy.create_engine(dsn)
+    report_id = "TEST-SCENARIO-01"
+    run_single_file_etl(test_settings, "test_amendment.xml")
+
+    # Act: Process the nullification file.
+    run_single_file_etl(test_settings, "test_nullification.xml")
+
+    # Assert: The record should be marked as nullified.
+    row = get_icsr_master_row(engine, report_id)
+    assert row is not None
+    assert row["is_nullified"] is True
+    # The version should be updated to the nullification's version.
+    assert row["date_of_most_recent_info"] == "20250103"
+    # The loader logic should preserve the data from the previous version
+    # if the nullification record is sparse.
+    assert row["senderidentifier"] == "SENDER-ID-UPDATED"
+
+
+def test_stale_amendment_is_ignored(db_container: PostgresContainer, test_settings: Settings):
+    """
+    Tests that processing an amendment with an older or same version date
+    does NOT update the existing record.
+    """
+    # Arrange: Load the newest version of the record first
+    dsn = db_container.get_connection_url()
+    engine = sqlalchemy.create_engine(dsn)
+    report_id = "TEST-SCENARIO-01"
+    run_single_file_etl(test_settings, "test_amendment.xml")
+
+    # Act: Process the stale amendment file
+    run_single_file_etl(test_settings, "test_stale_amendment.xml")
+
+    # Assert: The record should NOT be updated
+    row = get_icsr_master_row(engine, report_id)
+    assert row is not None
+    # Data should be from the 'test_amendment.xml' file, not the stale one.
+    assert row["date_of_most_recent_info"] == "20250102"
+    assert row["senderidentifier"] == "SENDER-ID-UPDATED"
+
+
+def test_idempotency_and_reprocessing(db_container: PostgresContainer, test_settings: Settings):
+    """
+    Tests that reprocessing the same files does not change the database state
+    and that an older version cannot overwrite a newer nullification.
+    """
+    # Arrange
+    dsn = db_container.get_connection_url()
+    engine = sqlalchemy.create_engine(dsn)
+    report_id = "TEST-SCENARIO-01"
+
+    # Act & Assert Phase 1: Run the full sequence
+    run_single_file_etl(test_settings, "test_insert.xml") # version 20250101
+    run_single_file_etl(test_settings, "test_amendment.xml") # version 20250102
+    run_single_file_etl(test_settings, "test_nullification.xml") # version 20250103
+
+    # Assert state after nullification
+    row_after_null = get_icsr_master_row(engine, report_id)
+    assert row_after_null is not None
+    assert row_after_null["is_nullified"] is True
+    assert row_after_null["date_of_most_recent_info"] == "20250103"
+
+    # Act & Assert Phase 2: Try to re-process the original insert (stale)
+    run_single_file_etl(test_settings, "test_insert.xml")
+    row_after_reinsert = get_icsr_master_row(engine, report_id)
+    # The record should be unchanged because the insert is older than the nullification
+    assert row_after_reinsert == row_after_null
+
+    # Act & Assert Phase 3: Reprocess the nullification file (idempotency)
+    run_single_file_etl(test_settings, "test_nullification.xml")
+    row_after_idempotency = get_icsr_master_row(engine, report_id)
+    # The record should be unchanged
+    assert row_after_idempotency == row_after_null


### PR DESCRIPTION
Adds a new integration test suite in `tests/test_loader_scenarios.py` to validate the core functionality of the `PostgresLoader`.

This suite uses `testcontainers` to create an ephemeral PostgreSQL database for each test, ensuring isolated and reliable execution.

The tests cover the following critical ICSR lifecycle scenarios as required by the FRD:
- Initial insertion of a new record.
- Successful amendment of an existing record with a newer version.
- Rejection of a stale amendment (older version).
- Correct handling of a nullification record, including preserving existing data from the previous version.
- Idempotency of the loading process and rejection of a stale record after a nullification has been processed.

New, valid test data files based on the project's sample XML have been added to `tests/data/` to support these scenarios.