### PR TITLE
Update project metadata and license information

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,1 +1,1 @@
-Copyright owner is Gowtham Rao rao@ohdsi.org year 2025
+Copyright 2025 Gowtham Rao <rao@ohdsi.org>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "py_load_eudravigilance"
 version = "0.1.0"
 description = "High-performance ETL for EudraVigilance ICSRs into relational databases."
 authors = ["Gowtham Rao <rao@ohdsi.org>"]
-license = "MIT"
+license = "Apache-2.0"
 readme = "README.md"
 packages = [{include = "py_load_eudravigilance", from = "src"}]
 


### PR DESCRIPTION
- Set the license to Apache-2.0 in pyproject.toml.
- Updated the NOTICE file with the correct copyright information.