### PR TITLE
feat(tests): Add robustness test for repeated singleton elements

### DIFF
--- a/tests/data/repeated_singleton_element.xml
+++ b/tests/data/repeated_singleton_element.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ichicsrMessage xmlns="urn:hl7-org:v3">
+    <safetyreport>
+        <safetyreportid>TEST-REPEATED-PATIENT-01</safetyreportid>
+        <patient>
+            <patientinitials>FIRST</patientinitials>
+            <patientsex>1</patientsex>
+        </patient>
+        <patient>
+            <patientinitials>SECOND</patientinitials>
+            <patientsex>2</patientsex>
+        </patient>
+    </safetyreport>
+</ichicsrMessage>

--- a/tests/test_parser_robustness.py
+++ b/tests/test_parser_robustness.py
@@ -189,3 +189,23 @@ def test_element_to_dict_with_no_namespace():
     result = _element_to_dict(root_element)
     expected = {"root": {"child": "text"}}
     assert result == expected
+
+
+def test_parse_with_repeated_singleton_element():
+    """
+    Tests that the parser correctly handles a case where an element that is
+    expected to be a singleton (like <patient>) appears multiple times.
+    The parser should only process the first instance.
+    """
+    xml_path = TEST_DIR / "data" / "repeated_singleton_element.xml"
+    with open(xml_path, "rb") as f:
+        xml_content = f.read()
+
+    results = list(parse_icsr_xml(io.BytesIO(xml_content)))
+
+    assert len(results) == 1
+    assert isinstance(results[0], dict)
+
+    # The parser should have extracted data from the *first* patient element
+    assert results[0]["patientinitials"] == "FIRST"
+    assert results[0]["patientsex"] == "1"


### PR DESCRIPTION
Adds a new unit test to verify the parser's behavior when faced with an XML structure that contains a repeated element where only a single instance is expected.

Specifically, this test introduces an XML file with two `<patient>` elements within a single `<safetyreport>`. It asserts that the parser correctly processes only the first `<patient>` element and ignores the second, which is the desired and safe behavior.

This enhances the robustness of the parser by explicitly testing and documenting its handling of this common type of structural anomaly, preventing potential regressions in the future.