### PR TITLE
Test: Add test for quadratic blowup attack

### DIFF
--- a/tests/data/quadratic_blowup.xml
+++ b/tests/data/quadratic_blowup.xml
@@ -1,0 +1,7 @@
+<!DOCTYPE kaboom [
+  <!ENTITY a "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">
+  <!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">
+  <!ENTITY c "&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;">
+  <!ENTITY d "&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;">
+]>
+<kaboom>&d;</kaboom>

--- a/tests/test_parser_robustness_extra.py
+++ b/tests/test_parser_robustness_extra.py
@@ -1,0 +1,20 @@
+"""
+Tests for parser robustness against various attacks.
+"""
+import pytest
+from lxml import etree
+from py_load_eudravigilance.parser import parse_icsr_xml, InvalidICSRError
+
+def test_quadratic_blowup_attack():
+    """
+    Tests that the parser is not vulnerable to the quadratic blowup attack.
+    The parser should not hang or crash, and it should not return any valid data.
+    """
+    with open("tests/data/quadratic_blowup.xml", "rb") as f:
+        results = list(parse_icsr_xml(f))
+        # The parser should not return any valid data.
+        # It might return an InvalidICSRError, or it might return nothing.
+        # The important thing is that it doesn't crash and doesn't return
+        # a dictionary of parsed data.
+        for result in results:
+            assert isinstance(result, InvalidICSRError)


### PR DESCRIPTION
This commit adds a new test to ensure the XML parser is not vulnerable to the "quadratic blowup" attack. This type of attack, also known as a "billion laughs" attack, uses nested entity expansion to consume large amounts of memory and CPU, potentially leading to a denial of service.

A new test file, `tests/test_parser_robustness_extra.py`, has been created to house this test. A corresponding malicious XML file, `tests/data/quadratic_blowup.xml`, is used as the test case.

The test confirms that the parser correctly handles this malicious input by not crashing and not returning any parsed data, which is the expected behavior of a robust parser.