### PR TITLE
feat: Add code coverage reporting to CI workflow (#62)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,10 @@ jobs:
       run: docker build -t py-load-eudravigilance-test .
 
     - name: Run tests in Docker container
-      run: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock py-load-eudravigilance-test
+      run: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $GITHUB_WORKSPACE:/app py-load-eudravigilance-test
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        # The user of this repo needs to set a CODECOV_TOKEN secret in their repository settings
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,4 +74,4 @@ line-length = 88
 profile = "black"
 
 [tool.pytest.ini_options]
-addopts = "--cov=src/py_load_eudravigilance --cov-report=term-missing --cov-report=html"
+addopts = "--cov=src/py_load_eudravigilance --cov-report=term-missing --cov-report=html --cov-report=xml"


### PR DESCRIPTION
This commit adds the ability for the GitHub Actions CI workflow to check for code coverage and publish the report to Codecov.

The following changes were made:
- The `pyproject.toml` file was modified to configure pytest to generate a coverage report in XML format.
- The `.github/workflows/ci.yml` file was updated to:
  - Mount the workspace directory into the Docker container to make the coverage report accessible to the runner.
  - Add a step to upload the coverage report to Codecov using the `codecov/codecov-action`.